### PR TITLE
Fix some audio sync issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 build/VfrToCfr.opensdf
 build/VfrToCfr.sdf
 build/*.suo
+build/.vs
 build/ipch
 build/Debug
 build/Release

--- a/doc/vfrtocfr.txt
+++ b/doc/vfrtocfr.txt
@@ -66,6 +66,10 @@ vfrtocfr( timecodes="timecodes.txt", fpsnum=24000, fpsden=1001 )
 
 audiodub( ffaudiosource("myclip.rm") )
 ---------------------------------------------------------------------
+If you are having audio sync issues you may want to dub the audio before applying
+vfrtocfr. If the clip has audio, it will be fitted to match the length of the video.
+This usually means either trimming or padding the audio by a few milliseconds.
+
 _Hint: ffaudiosource may fail to load realmedia audio if it's in cook format, so in
 that case just dump the audio to a wave file and load that file instead using
 wavsource or ffaudiosource._

--- a/src/Interface.cpp
+++ b/src/Interface.cpp
@@ -1,6 +1,6 @@
 #include "VfrToCfr.h"
 
-#define VERSION "1.0"
+#define VERSION "1.2"
 
 AVSValue __cdecl Create_VfrToCfr(AVSValue args, void* user_data, IScriptEnvironment* env);
 

--- a/src/framecalc.cpp
+++ b/src/framecalc.cpp
@@ -124,7 +124,7 @@ int FrameCalculator::getInterpolationInfo(InterpolationInfo* interp, int frame) 
     } else {                              // sought frame is in between two real frames (doesn't exist and would need to be created)
         interp->frame1 = v[0].frameno;
         interp->frame2 = v[1].frameno;
-        interp->pct = 100 * (v[1].display_time - display_time) / (v[1].display_time - v[0].display_time);
+        interp->pct = 100 * (display_time - v[0].display_time) / (v[1].display_time - v[0].display_time);
     }
     return 0;
 }


### PR DESCRIPTION
I recently did some filming with my phone (Samsung Galaxy S10e). After trimming and splicing the clips together with avisynth I noticed the sound got out of sync fairly quickly. Turns out phone cameras film in VFR.
I tried this plugin which made the sync better, but not perfect. The sync issues were still noticeable.

I did some digging into the source and found a few things to improve. See if you want to incorporate them.
Here is a quick summary:
- Improve the source frame selection process by utilizing the pct value in timecode.
- I then found a bug in the calculation of pct.
- Changed the calculation of num_frames to be based on the timecode of the last frame and the desired FPS. This should yield a near perfect duration of the video track.
- For the sound to not get out of sync it is now trimmed or padded to perfectly match the video track length.
- I also got a nothing by a black screen when passing my clips through vfrtocrf. It was fixed by moving the call to lazyInitialize to the ctor.

Hope you approve of the changes. Let me know if you have and questions.